### PR TITLE
Add a generic utility to get data dir

### DIFF
--- a/dep11/generator.py
+++ b/dep11/generator.py
@@ -33,7 +33,7 @@ import logging as log
 from dep11 import MetadataExtractor, DataCache, build_cpt_global_id
 from dep11.component import DEP11Component, get_dep11_header, dict_to_dep11_yaml
 from dep11.iconfinder import ContentsListIconFinder
-from dep11.utils import read_packages_dict_from_file
+from dep11.utils import get_data_dir, read_packages_dict_from_file
 from dep11.hints import get_hint_tag_info
 from dep11.validate import DEP11Validator
 
@@ -383,12 +383,7 @@ class HTMLGenerator:
         if not self._html_url:
             self._html_url = "."
 
-        template_dir = os.path.dirname(os.path.realpath(__file__))
-        template_dir = os.path.realpath(os.path.join(template_dir, "..", "data", "templates", "default"))
-        if not os.path.isdir(template_dir):
-            template_dir = os.path.join(sys.prefix, "share", "dep11", "templates")
-
-        self._template_dir = template_dir
+        self._template_dir = os.path.join(get_data_dir(), "templates", "default")
 
         self._distro_name = conf.get("DistroName")
         if not self._distro_name:

--- a/dep11/hints.py
+++ b/dep11/hints.py
@@ -20,6 +20,8 @@ import sys
 import yaml
 import logging as log
 
+from dep11.utils import get_data_dir
+
 __all__ = []
 
 _DEP11_HINT_DESCRIPTIONS = None
@@ -59,12 +61,7 @@ def get_hints_index_fname():
     Find the YAML tag description, even if the DEP-11 metadata generator
     is not properly installed.
     '''
-    fname = os.path.join(sys.prefix, "share", "dep11", "dep11-hints.yml")
-    if os.path.isfile(fname):
-        return fname
-
-    fname = os.path.dirname(os.path.realpath(__file__))
-    fname = os.path.realpath(os.path.join(fname, "..", "data", "dep11-hints.yml"))
+    fname = os.path.join(get_data_dir(), "dep11-hints.yml")
     if os.path.isfile(fname):
         return fname
 

--- a/dep11/utils.py
+++ b/dep11/utils.py
@@ -17,6 +17,7 @@
 
 import gzip
 from apt_pkg import TagFile, version_compare
+import os
 
 def str_enc_dec(val):
     '''
@@ -69,3 +70,13 @@ def build_cpt_global_id(cptid, checksum):
         gid = "%s/%s/%s" % (cptid[0].lower(), cptid, checksum)
 
     return gid
+
+def get_data_dir():
+    """Return data directory path. Check first in master, then virtualenv or installed system version."""
+
+    dep11_dir = os.path.dirname(os.path.realpath(__file__))
+    data_dir = os.path.join(os.path.dirname(dep11_dir), "data")
+    if os.path.isdir(data_dir):
+        return data_dir
+
+    return os.path.join(sys.prefix, "share", "dep11")


### PR DESCRIPTION
Some functions in upstream code are checking first master, then virtualenv/system installed version and other functions are doing the opposite. Introduce a generic get data dir utility to ensure we always check first a possible checkout, and then virtualenv/system installed version.

Also, when using it, ensure we always look in the "default" directory, even for system templates, as this is what is installed (<prefix>/share/dep11/templates/default). This fix a bug when the template won't be found.
Ensure we always look for default. Templating system will then be able to be implemented.

I'm opened to any suggestion if anything is needed :)
