### PR TITLE
metainfo parser: Cope with XML namespaces

### DIFF
--- a/dep11/parsers.py
+++ b/dep11/parsers.py
@@ -293,7 +293,9 @@ def read_appstream_upstream_xml(cpt, xml_content):
     '''
     root = None
     try:
+        xml_content = re.sub(r'\sxmlns="[^"]+"', '', xml_content, count=1)
         root = et.fromstring(bytes(xml_content, 'utf-8'))
+
     except Exception as e:
         cpt.add_hint("metainfo-parse-error", str(e))
         return


### PR DESCRIPTION
We currently fail to parse gnome-terminal because we're parsing the
metainfo file as having no 'id' tag, but it does.

ElementTree includes the namespace when asking for tag names, if one is
supplied. Look at just the end of the returned tags and attributes,
where the actual name is, to deal with this.

This fixes the extraction of gnome-terminal as seen in Debian & Ubuntu
