### PR TITLE
iconhandler: Get theme contents from the .deb file, not Contents

### DIFF
--- a/dep11/extractor.py
+++ b/dep11/extractor.py
@@ -321,6 +321,6 @@ class MetadataExtractor:
 
         # ensure DebFile is closed so we don't run out of FDs when too many
         # files are open.
-        pkg.close_debfile()
+        pkg.close()
 
         return cpts

--- a/dep11/package.py
+++ b/dep11/package.py
@@ -61,7 +61,7 @@ class Package:
         return "%s/%s/%s" % (self.name, self.version, self.arch)
 
 
-    def close_debfile(self):
+    def close(self):
         self._debfile = None
 
 


### PR DESCRIPTION
How about doing something like this?

I fixed adwaita-icon-theme to include more icons, but we aren't getting them currently because Contents is updated only once per week on Launchpad. If we look inside the theme's debs directly instead of using Contents then we get its changes right away.
