### PR TITLE
contentsfile: Accept any number of '/'-separate components in package name

### DIFF
--- a/dep11/contentsfile.py
+++ b/dep11/contentsfile.py
@@ -38,10 +38,7 @@ def _file_pkg_from_contents_line(raw_line):
     parts = line.split(" ", 1)
     path = parts[0].strip()
     group_pkg = parts[1].strip()
-    if "/" in group_pkg:
-        pkgname = group_pkg.split("/", 1)[1].strip()
-    else:
-        pkgname = group_pkg
+    pkgname = group_pkg.split("/")[-1].strip()
     return path, pkgname
 
 


### PR DESCRIPTION
For non-main, ubuntu "location" components are in the form component/section/package - we're only interested in the last.

AFAICS Debian is always section/package - but the same code should work there too, unless I'm missing something.

```
In [1]: "foo/bar".split("/")[-1].strip()
Out[1]: 'bar'

In [2]: "foo/bar/baz".split("/")[-1].strip()
Out[2]: 'baz'

In [3]: "foo".split("/")[-1].strip()
Out[3]: 'foo'
```
