### PR TITLE
Look through dependencies for absolute-pathed icons

### DIFF
--- a/dep11/iconhandler.py
+++ b/dep11/iconhandler.py
@@ -204,6 +204,23 @@ class IconHandler:
         if icon_str.startswith("/"):
             if icon_str[1:] in pkg.debfile.get_filelist():
                 return self._store_icon(pkg, cpt, cpt_export_path, icon_str[1:], IconSize(64))
+            else:
+                def search_depends(pkg, seen_packages=list()):
+                    seen_packages.append(pkg.name)
+                    # look through the first level of dependencies
+                    for dep in pkg.depends:
+                        if icon_str[1:] in dep.debfile.get_filelist():
+                            return self._store_icon(dep, cpt, cpt_export_path, icon_str[1:], IconSize(64))
+
+                    # then the rest
+                    for dep in pkg.depends:
+                        if dep.name not in seen_packages and search_depends(dep, seen_packages):
+                            return True
+
+                    return False
+
+                if search_depends(pkg):
+                    return True
         else:
             icon_str = os.path.basename(icon_str)
 


### PR DESCRIPTION
I noticed that emacs24 wasn't working because of this (then I fixed this example by: https://launchpadlibrarian.net/245813919/emacs24_24.5+1-1ubuntu6_24.5+1-1ubuntu7.diff.gz), and searched and found some others (idle-pythonX.Y, postbooks, widelands, probably others --- see ~laney/scan.py on mekeel.debian.org).

There's a special codepath for looking into .deb files directly when the icon paths are absolute (not sure why we don't use the Contents information here --- because it is laggy?). It's not that unheard of for people to put these icons into a -common file (even a dependency of a dependency, hence the recursive check). So look in .debs too.
