### PR TITLE
generator: Store the suites we've seen a package in, to track packages as they move around

### DIFF
--- a/dep11/datacache.py
+++ b/dep11/datacache.py
@@ -141,7 +141,7 @@ class DataCache:
                 return
             suites = yaml.load(suites)
             suites.discard(suite)
-            txn.put(pkgid, yaml.dump(suites))
+            txn.put(pkgid, tobytes(yaml.dump(suites)))
 
     def get_cpt_gids_for_pkg(self, pkgid):
         pkgid = tobytes(pkgid)

--- a/dep11/datacache.py
+++ b/dep11/datacache.py
@@ -139,6 +139,7 @@ class DataCache:
             suites = txn.get(pkgid)
             if not suites:
                 return
+            suites = yaml.load(suites)
             suites.discard(suite)
             txn.put(pkgid, yaml.dump(suites))
 

--- a/dep11/datacache.py
+++ b/dep11/datacache.py
@@ -21,6 +21,7 @@ import shutil
 import logging as log
 import lmdb
 from math import pow
+import yaml
 
 
 def tobytes(s):
@@ -49,12 +50,13 @@ class DataCache:
 
 
     def open(self, cachedir):
-        self._dbenv = lmdb.open(cachedir, max_dbs=4, map_size=self._map_size, metasync=False)
+        self._dbenv = lmdb.open(cachedir, max_dbs=5, map_size=self._map_size, metasync=False)
 
         self._pkgdb = self._dbenv.open_db(b'packages')
         self._hintsdb = self._dbenv.open_db(b'hints')
         self._datadb = self._dbenv.open_db(b'metadata')
         self._statsdb = self._dbenv.open_db(b'statistics')
+        self._suitesdb = self._dbenv.open_db(b'suites')
 
         self._opened = True
         self.cache_dir = cachedir
@@ -71,6 +73,7 @@ class DataCache:
         self._datadb = None
         self._dbenv = None
         self._statsdb = None
+        self._suitesdb = None
         self._opened = False
 
 
@@ -107,6 +110,37 @@ class DataCache:
         with self._dbenv.begin(db=self._pkgdb, write=True) as txn:
             txn.put(pkgid, b'ignore')
 
+    def package_in_suite(self, pkgid, suite):
+        pkgid = tobytes(pkgid)
+        with self._dbenv.begin(db=self._suitesdb) as txn:
+            yaml_suites = txn.get(pkgid)
+
+            if not yaml_suites:
+                return False
+
+            suites = yaml.load(yaml_suites)
+
+            return suite in suites
+
+    def add_package_to_suite(self, pkgid, suite):
+        pkgid = tobytes(pkgid)
+        with self._dbenv.begin(db=self._suitesdb, write=True) as txn:
+            suites = txn.get(pkgid)
+            if not suites:
+                suites = set()
+            else:
+                suites = yaml.load(suites)
+            suites.add(suite)
+            txn.put(pkgid, tobytes(yaml.dump(suites)))
+
+    def remove_package_from_suite(self, pkgid, suite):
+        pkgid = tobytes(pkgid)
+        with self._dbenv.begin(db=self._suitesdb, write=True) as txn:
+            suites = txn.get(pkgid)
+            if not suites:
+                return
+            suites.discard(suite)
+            txn.put(pkgid, yaml.dump(suites))
 
     def get_cpt_gids_for_pkg(self, pkgid):
         pkgid = tobytes(pkgid)
@@ -172,7 +206,6 @@ class DataCache:
             with self._dbenv.begin(db=self._pkgdb, write=True) as txn:
                 txn.put(pkgid, b'seen')
 
-
     def get_hints(self, pkgid):
         pkgid = tobytes(pkgid)
         with self._dbenv.begin(db=self._hintsdb) as txn:
@@ -205,6 +238,8 @@ class DataCache:
             pktxn.delete(pkgid)
         with self._dbenv.begin(db=self._hintsdb, write=True) as htxn:
             htxn.delete(pkgid)
+        with self._dbenv.begin(db=self._suitesdb, write=True) as stxn:
+            stxn.delete(pkgid)
 
 
     def is_ignored(self, pkgid):
@@ -360,6 +395,14 @@ class DataCache:
                 pkid_str = str(pkid, 'utf-8')
                 if pkid_str.startswith(pkgname+'/'):
                      htxn.delete(pkid)
+                     data_removed = True
+
+        with self._dbenv.begin(db=self._suitesdb, write=True) as stxn:
+            cursor = stxn.cursor()
+            for pkid, data in cursor:
+                pkid_str = str(pkid, 'utf-8')
+                if pkid_str.startswith(pkgname+'/'):
+                     stxn.delete(pkid)
                      data_removed = True
 
         return data_removed

--- a/dep11/extractor.py
+++ b/dep11/extractor.py
@@ -33,11 +33,12 @@ class MetadataExtractor:
     Takes a deb file and extracts component metadata from it.
     '''
 
-    def __init__(self, suite_name, component, dcache, icon_handler):
+    def __init__(self, suite_name, component, arch, dcache, icon_handler):
         '''
         Initialize the object with List of files.
         '''
         self._suite_name = suite_name
+        self._arch = arch
         self._archive_component = component
         self._export_dir = dcache.media_dir
         self._dcache = dcache
@@ -318,6 +319,7 @@ class MetadataExtractor:
         if self.write_to_cache:
             # write the components we found to the cache
             self._dcache.set_components(pkgid, cpts)
+            self._dcache.add_package_to_suite(pkgid, "%s/%s/%s" % (self._suite_name, self._archive_component, self._arch))
 
         # ensure DebFile is closed so we don't run out of FDs when too many
         # files are open.


### PR DESCRIPTION
It's not enough to just see if there are new components, since things
can move between suites, for example when transitioning from unstable to
testing, or in Ubuntu's case xenial -> xenial-proposed. Instead we now do two things:
- Store the suites that we've put a package in. When reading Packages,
  we then check to see if we've seen the package in that suite. If
  not, we need to update.
- Read the previous output. The previous step will leave deleted
  packages dangling. We check that we still see all packages we saw
  before. If not, then a package has been deleted and we need to
  update.

---

I noticed because this happened last night
- I uploaded Cheese to get X-AppStream-Ignore=true in cheese.desktop (the renaming thing)
- It built faster on amd64 than other arches
- The first time we ran here, the amd64 binaries were published in xenial-proposed but none of the others were
- The next time we ran, all architectures were built and britney had copied Cheese to xenial proper
- Our output contained cheese/amd64 in xenial-propsed and all other arches in xenial

We check if we've seen a package id (package/version/arch) before, to skip if we haven't got any new uploads. This makes sense, and is quite necessary now that we have the `Time` header. But we also need to check the suite. I added a new table (correct term?) into the lmdb database to record in which suites we've seen a package. If we've not seen it in the current suite then we need to regenerate the output. No extraction needs to happen - the previous one is okay. Then you have to take care of the removal case, and for that I couldn't think of another way besides scanning the previous output.

This is the first time I've looked at the database at all, please review that. I'm already running this in production (didn't have a real testcase) & didn't notice problems so far. The first run will print the 'Seen' line for all packages with components as it's populating the table for the first time.
